### PR TITLE
refactor(docs): replace embedded Swagger UI with link badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Build output
 site/
 
+# Local virtualenv for previewing the docs (mkdocs serve)
+.venv/
+.preview_site/
+
 # Encryptcontent plugin cache
 encryptcontent.cache
 

--- a/docs/agro/cropid/FieldLevel_CropMask_API_v11092025.md
+++ b/docs/agro/cropid/FieldLevel_CropMask_API_v11092025.md
@@ -130,9 +130,7 @@ Return the **year(s)** in which a **specific crop** has been detected within a g
 
 Interactive API documentation is available via Swagger:
 
-👉 [CropMask API Swagger (PROD)](https://api.geosys-na.net/cropmasks/v1/swagger/index.html)
-
-<swagger-ui src="https://api.geosys-na.net/cropmasks/v1/swagger/v1/swagger.json"/>
+<!-- md:swagger https://api.geosys-na.net/cropmasks/v1/swagger/index.html -->
  
 You can use this interface to:
 

--- a/docs/agro/library/Api_reference.md
+++ b/docs/agro/library/Api_reference.md
@@ -94,8 +94,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     OAuth 2.0 authentication service for secure API access. Provides token-based authentication with configurable scopes and expiration.
     
-    [:simple-swagger: Swagger](https://identity.geosys-na.com/v2.1/swagger.html){ .md-button }
-    [:octicons-link-external-16: Details](https://identity.geosys-na.com/v2.1/){ .md-button }
+    <!-- md:swagger-button https://identity.geosys-na.com/v2.1/swagger.html -->
+    <!-- md:details-button https://identity.geosys-na.com/v2.1/ -->
 
 -   :material-database: **Entity Management**
 
@@ -103,8 +103,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Unified store for agricultural master data including fields, seasons, growers, and farm hierarchies. Supports CRUD operations for Ag entities.
     
-    [:simple-swagger: Swagger](https://api.geosys-na.net/master-data-management/v6/swagger){ .md-button }
-    [:octicons-link-external-16: Details ](../index.md){ .md-button }
+    <!-- md:swagger-button https://api.geosys-na.net/master-data-management/v6/swagger -->
+    <!-- md:details-button ../index.md -->
 
 -   :material-cloud-upload: **Analytic Store**
 
@@ -112,8 +112,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Access various analytics derived from imagery and weather data.
     
-    [:simple-swagger: Swagger](https://api.geosys-na.net/analytics/swagger/index.html){ .md-button }
-    [:octicons-link-external-16: Details ](../index.md){ .md-button }
+    <!-- md:swagger-button https://api.geosys-na.net/analytics/swagger/index.html -->
+    <!-- md:details-button ../index.md -->
 
 </div>
 
@@ -129,8 +129,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Automatic field boundary delineation using deep learning and satellite imagery. Generates accurate field polygons without manual digitization.
     
-    [:simple-swagger: Swagger](https://api.geosys-na.net/field-borders/v1/swagger){ .md-button }
-    [:octicons-link-external-16: Details ](./Automatic_Field_Borders.md){ .md-button }
+    <!-- md:swagger-button https://api.geosys-na.net/field-borders/v1/swagger -->
+    <!-- md:details-button ./Automatic_Field_Borders.md -->
 
 -   :material-chart-line: **Time Series**
 
@@ -138,8 +138,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Historical and near-real-time vegetation indices time series. Cloud-masked, smoothed data for accurate temporal analysis of crop development.
     
-    [:simple-swagger: Swagger](https://api.geosys-na.net/vegetation-time-series/v1/swagger){ .md-button }
-    [:octicons-link-external-16: Details](./Vegetation_time_series.md){ .md-button }
+    <!-- md:swagger-button https://api.geosys-na.net/vegetation-time-series/v1/swagger -->
+    <!-- md:details-button ./Vegetation_time_series.md -->
 
 -   :material-barley: **Crop ID**
 
@@ -147,8 +147,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     AI-powered crop type classification using multi-temporal satellite imagery. Identifies major crop types with confidence scores and validation metrics.
     
-    [:simple-swagger: Swagger](https://api.geosys-na.net/cropmasks/v1/swagger/index.html){ .md-button }
-    [:octicons-link-external-16: Details](./docs/agro/cropid/index.md){ .md-button }
+    <!-- md:swagger-button https://api.geosys-na.net/cropmasks/v1/swagger/index.html -->
+    <!-- md:details-button ./docs/agro/cropid/index.md -->
     
 
 -   :material-layers: **Layer Service**
@@ -157,8 +157,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Access satellite imagery layers, vegetation indices, and derived analytics products. Supports multiple sensors and on-demand processing.
     
-    [:simple-swagger: Swagger](https://api.geosys-na.net/layers/v1/swagger){ .md-button }
-    [:octicons-link-external-16: Details](./Map-types.md){ .md-button }
+    <!-- md:swagger-button https://api.geosys-na.net/layers/v1/swagger -->
+    <!-- md:details-button ./Map-types.md -->
 
 -   :material-map: **Vegetation Index Maps**
 
@@ -167,8 +167,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     Generate field-level vegetation index maps including NDVI, EVI, NDRE. Supports prescription mapping and precision agriculture workflows.
     
 
-    [:simple-swagger: Swagger](https://api.geosys-na.net/field-level-maps/v5/swagger){ .md-button }
-    [:octicons-link-external-16: Details](./Field%20Level%20Maps.md){ .md-button }
+    <!-- md:swagger-button https://api.geosys-na.net/field-level-maps/v5/swagger -->
+    <!-- md:details-button ./Field%20Level%20Maps.md -->
 
 -   :material-weather-cloudy: **Field Weather**
 
@@ -176,8 +176,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Historical weather data and forecasts for agricultural fields. Includes temperature, precipitation, humidity, and derived agro-meteorological indices.
     
-    [:simple-swagger: Swagger](https://api.geosys-na.net/Weather/v1/swagger){ .md-button }
-    [:octicons-link-external-16: Details](./Api_reference.md){ .md-button }
+    <!-- md:swagger-button https://api.geosys-na.net/Weather/v1/swagger -->
+    <!-- md:details-button ./Api_reference.md -->
 
 </div>
 
@@ -193,8 +193,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Detect significant changes in field conditions using multi-temporal satellite analysis. Identifies anomalies, disturbances, and rapid vegetation changes.
     
-    [:simple-swagger: Swagger](https://change-index.aws.geosys.com/docs){ .md-button }
-    [:octicons-link-external-16: Details](./Change_Index.md){ .md-button }
+    <!-- md:swagger-button https://change-index.aws.geosys.com/docs -->
+    <!-- md:details-button ./Change_Index.md -->
 
 -   :material-chart-bar: **Benchmark**
 
@@ -202,8 +202,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Compare field performance against historical patterns, regional averages, and peer benchmarks. Supports relative performance analysis.
     
-    [:simple-swagger: Swagger](){ .md-button }
-    [:octicons-link-external-16: Details](./Field_benchmark.md){ .md-button }
+    <!-- md:swagger-button  -->
+    <!-- md:details-button ./Field_benchmark.md -->
 
 -   :material-monitor-dashboard: **In-Season Monitoring**
 
@@ -211,8 +211,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Real-time crop performance monitoring combining satellite data, weather, and agronomic models. Provides actionable insights for in-season decisions.
     
-    [:simple-swagger: Swagger](https://5gciu5p2msxwjrt54fks3kvvxu0oxdyr.lambda-url.us-east-1.on.aws/docs){ .md-button }
-    [:octicons-link-external-16: Details](./inseason_monitoring.md){ .md-button }
+    <!-- md:swagger-button https://5gciu5p2msxwjrt54fks3kvvxu0oxdyr.lambda-url.us-east-1.on.aws/docs -->
+    <!-- md:details-button ./inseason_monitoring.md -->
 
 </div>
 
@@ -230,11 +230,11 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     
     **Historical:** 
-    [:simple-swagger: Swagger](https://historical-potential-risk-score.aws.geosys.com/docs){ .md-button }
-    [:octicons-link-external-16: Details](./Historical_Potential_Score.md){ .md-button }
-        **In-Season:** 
-    [:simple-swagger: Swagger](http://inseason-potential-score.aws.geosys.com/docs){ .md-button }
-    [:octicons-link-external-16: Details](./In-season_Potential_Score.md){ .md-button }
+    <!-- md:swagger-button https://historical-potential-risk-score.aws.geosys.com/docs -->
+    <!-- md:details-button ./Historical_Potential_Score.md -->
+    **In-Season:** 
+    <!-- md:swagger-button http://inseason-potential-score.aws.geosys.com/docs -->
+    <!-- md:details-button ./In-season_Potential_Score.md -->
 
 -   :material-leaf-maple: **Environmental Compliance**
 
@@ -242,8 +242,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Track and report environmental sustainability metrics including carbon sequestration, conservation practices, and regulatory compliance.
     
-    [:simple-swagger: Swagger](https://api.geosys-na.net/reporting/environmentalcompliance/v1/swagger){ .md-button }
-    [:octicons-link-external-16: Details](./CRA.md){ .md-button }
+    <!-- md:swagger-button https://api.geosys-na.net/reporting/environmentalcompliance/v1/swagger -->
+    <!-- md:details-button ./CRA.md -->
 
 -   :material-calendar-check: **ZARC Agricultural Risk**
 
@@ -252,8 +252,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     Brazilian Agricultural Climate Risk Zoning (ZARC) compliance service. Determines optimal planting windows based on climate risk analysis.
     
 
-    [:simple-swagger: Swagger](https://zvjihjkwfwohudwcnbhjbpsudq0jhszp.lambda-url.us-east-1.on.aws/docs){ .md-button }
-    [:octicons-link-external-16: Details](./ZARC.md){ .md-button }
+    <!-- md:swagger-button https://zvjihjkwfwohudwcnbhjbpsudq0jhszp.lambda-url.us-east-1.on.aws/docs -->
+    <!-- md:details-button ./ZARC.md -->
 
 </div>
 
@@ -269,8 +269,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Automated detection of crop emergence dates using satellite-based phenology analysis. Monitors planting window and early growth stages.
     
-    [:simple-swagger: Swagger](https://emergence-detection.aws.geosys.com/docs){ .md-button }
-    [:octicons-link-external-16: Details](./Emergence.md){ .md-button }
+    <!-- md:swagger-button https://emergence-detection.aws.geosys.com/docs -->
+    <!-- md:details-button ./Emergence.md -->
 
 -   :material-sprout-outline: **Planted Area**
 
@@ -278,8 +278,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Accurate estimation of planted acreage using crop identification and field boundary analysis. Supports compliance and acreage reporting.
     
-    [:simple-swagger: Swagger](https://planted-area.aws.geosys.com/docs){ .md-button }
-    [:octicons-link-external-16: Details](./Planted_Area.md){ .md-button }
+    <!-- md:swagger-button https://planted-area.aws.geosys.com/docs -->
+    <!-- md:details-button ./Planted_Area.md -->
 
 -   :material-leaf: **Greenness**
 
@@ -287,8 +287,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Monitor crop canopy development and vegetation vigor through growing season. Tracks greenness progression and identifies stress periods.
     
-    [:simple-swagger: Swagger](https://zn6hzsqoyoe3qgaoau4ssgpq440vtmpa.lambda-url.us-east-1.on.aws/docs){ .md-button }
-    [:octicons-link-external-16: Details](./greenness.md){ .md-button }
+    <!-- md:swagger-button https://zn6hzsqoyoe3qgaoau4ssgpq440vtmpa.lambda-url.us-east-1.on.aws/docs -->
+    <!-- md:details-button ./greenness.md -->
 
 -   :material-check-circle: **Harvest Readiness**
 
@@ -297,8 +297,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     Assess crop maturity and harvest readiness using vegetation indices and phenology models. Optimizes harvest timing decisions.
     
 
-    [:simple-swagger: Swagger](https://harvest-detection.aws.geosys.com/docs){ .md-button }
-    [:octicons-link-external-16: Details](./Harvest_Detection.md){ .md-button }
+    <!-- md:swagger-button https://harvest-detection.aws.geosys.com/docs -->
+    <!-- md:details-button ./Harvest_Detection.md -->
 
 -   :material-tractor: **Harvest Detection**
 
@@ -306,8 +306,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Real-time harvest date identification and progress monitoring. Tracks harvest operations across fields and regions using change detection.
     
-    [:simple-swagger: Swagger](https://harvest-detection.aws.geosys.com/docs){ .md-button }
-    [:octicons-link-external-16: Details](./Harvest_Detection.md){ .md-button }
+    <!-- md:swagger-button https://harvest-detection.aws.geosys.com/docs -->
+    <!-- md:details-button ./Harvest_Detection.md -->
 
 -   :material-tractor: **Disease risk**
 
@@ -315,8 +315,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Evaluate disease risk on location for Corn and Soybeans.
     
-    [:simple-swagger: Swagger](https://t7izeqf7q5t4xseagqap5ev7xm0xpmmh.lambda-url.us-east-1.on.aws/v1/docs){ .md-button }
-    [:octicons-link-external-16: Details](./disease_risk.md){ .md-button }
+    <!-- md:swagger-button https://t7izeqf7q5t4xseagqap5ev7xm0xpmmh.lambda-url.us-east-1.on.aws/v1/docs -->
+    <!-- md:details-button ./disease_risk.md -->
 
 </div>
 
@@ -332,8 +332,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     <!-- md:flag experimental --> Detect tillage practices and soil disturbance events using radar and optical imagery. Supports conservation agriculture monitoring and carbon programs.
     
-    [:simple-swagger: Swagger](https://api.geosys.com/processors/tillage/v1/docs){ .md-button }
-    [:octicons-link-external-16: Details](./){ .md-button }
+    <!-- md:swagger-button https://api.geosys.com/processors/tillage/v1/docs -->
+    <!-- md:details-button ./ -->
 
 -   :material-flower: **Cover Crop**
 
@@ -341,8 +341,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     <!-- md:flag experimental --> Satellite-based cover crop detection and coverage analysis. Quantifies cover crop presence for sustainability programs.
     
-    [:simple-swagger: Swagger](https://api.geosys.com/processors/cover-crop/v1/docs){ .md-button }
-    [:octicons-link-external-16: Details](./){ .md-button }
+    <!-- md:swagger-button https://api.geosys.com/processors/cover-crop/v1/docs -->
+    <!-- md:details-button ./ -->
 
 -   :material-weight: **Cover Crop Biomass** 
 
@@ -350,8 +350,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     <!-- md:flag experimental --> Estimate cover crop biomass and carbon sequestration potential. Supports carbon credit programs and soil health initiatives.
 
-    [:simple-swagger: Swagger](https://api.geosys.com/processors/cover-crop/v1/docs){ .md-button }
-    [:octicons-link-external-16: Details](){ .md-button }
+    <!-- md:swagger-button https://api.geosys.com/processors/cover-crop/v1/docs -->
+    <!-- md:details-button  -->
 
 -   :material-weight: **Baresoil** 
 
@@ -359,8 +359,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     <!-- md:flag experimental --> Estimate the number of days with bare soil exposed.
     
-    [:simple-swagger: Swagger](https://avuqeoz2lrpi2s5qovww5k4vca0itlyy.lambda-url.us-east-1.on.aws/v1/docs){ .md-button }
-    [:octicons-link-external-16: Details](./baresoil.md){ .md-button }
+    <!-- md:swagger-button https://avuqeoz2lrpi2s5qovww5k4vca0itlyy.lambda-url.us-east-1.on.aws/v1/docs -->
+    <!-- md:details-button ./baresoil.md -->
 
 </div>
 ---
@@ -375,8 +375,8 @@ Browse our comprehensive API documentation across all EarthDaily Agro analytics.
     
     Large-scale crop monitoring and analytics for regions, counties, and administrative boundaries. Supports portfolio analysis and market intelligence.
     
-    [:simple-swagger: Swagger](https://api.geosys-na.net/Agriquest/Geosys.AgriQuest.CropMonitoring.WebApi/v0/swagger/ui/index){ .md-button }
-    [:octicons-link-external-16: Details](./Regional_Monitoring.md){ .md-button }
+    <!-- md:swagger-button http://api.geosys.internal/Agriquest/Geosys.Agriquest.CropMonitoring.WebApi/v0/swagger/ -->
+    <!-- md:details-button ./Regional_Monitoring.md -->
 
 </div>
 

--- a/docs/agro/library/Automatic_Field_Borders.md
+++ b/docs/agro/library/Automatic_Field_Borders.md
@@ -27,7 +27,7 @@ It leverages super-resolution Sentinel-2 imagery at 1-meter resolution to deline
 
 ## ⚙️ API 
 
-<swagger-ui src="https://api.geosys-na.net/field-borders/v1/swagger/v1/swagger.json"/>
+<!-- md:swagger https://api.geosys-na.net/field-borders/v1/swagger/index.html -->
 
 ---
 

--- a/docs/agro/library/CRA.md
+++ b/docs/agro/library/CRA.md
@@ -51,9 +51,9 @@ Detailed description of each dataset is available on the [Environmental Layers](
 
 ---
 
-## ⚙️ API Access
+## ⚙️ Swagger Access
 
-<swagger-ui src="https://api.geosys-na.net/reporting/environmentalcompliance/v1/swagger/index.html"/>
+<!-- md:swagger https://api.geosys-na.net/reporting/environmentalcompliance/v1/swagger/index.html -->
 
 ---
 

--- a/docs/agro/library/CRA_Layers.md
+++ b/docs/agro/library/CRA_Layers.md
@@ -30,9 +30,9 @@ The datasets include CAR property boundaries, SIGEF and SNCI land registries, co
 
 ---
 
-## ⚙️ API Access
+## ⚙️ Swagger Access
 
-<swagger-ui src="https://api.geosys-na.net/layers/v1/swagger/v1/swagger.json"/>
+<!-- md:swagger https://api.geosys-na.net/layers/v1/swagger/index.html -->
 
 ---
 
@@ -80,9 +80,9 @@ The following table lists all available environmental layers. Hover over acronym
 | BR_CONSERVATION_UNITS_POINTS      | Unidades de Conservação (pontos)               | Conservation Units of Full Protection seek nature preservation and only the indirect use of their natural resources is allowed.                                                                                                                                                                                                                                                                  |
 ---
 
-## ⚙️ API Access
+## ⚙️ Swagger Access
 
-<swagger-ui src="https://api.geosys-na.net/reporting/environmentalcompliance/v1/swagger/index.html"/>
+<!-- md:swagger https://api.geosys-na.net/reporting/environmentalcompliance/v1/swagger/index.html -->
 
 ---
 

--- a/docs/agro/library/Change_Index.md
+++ b/docs/agro/library/Change_Index.md
@@ -86,7 +86,7 @@ Change Index is based on three components of change using the field's NDVI value
 
 Here is the Change index [API documentation](https://change-index.aws.geosys.com/docs#/Change%20Index%20Compute):
 
-<swagger-ui src="https://change-index.aws.geosys.com/docs"/>
+<!-- md:swagger https://change-index.aws.geosys.com/docs -->
 
 ---
 

--- a/docs/agro/library/Emergence.md
+++ b/docs/agro/library/Emergence.md
@@ -40,7 +40,7 @@ The analytic uses NDVI (1) time series data available at both LR (2) and MR (3) 
 
 ## ⚙️ API
 
-<swagger-ui src="https://emergence-detection.aws.geosys.com/openapi.json"/>
+<!-- md:swagger https://emergence-detection.aws.geosys.com/docs -->
 
 ---
 

--- a/docs/agro/library/Emergence_Delay.md
+++ b/docs/agro/library/Emergence_Delay.md
@@ -25,7 +25,7 @@ This analytic compares the current season emergence to the average historical em
 
 ## ⚙️API 
 
-<swagger-ui src="https://emergence-detection.aws.geosys.com/openapi.json"/>
+<!-- md:swagger https://emergence-detection.aws.geosys.com/docs -->
 
 ## ⚙️ Parameters & Variables
 

--- a/docs/agro/library/Field Level Maps.md
+++ b/docs/agro/library/Field Level Maps.md
@@ -9,8 +9,6 @@ keywords:
   - zoning
 ---
 
-<!-- md:swagger API|https://api.geosys-na.net/field-level-maps/v5/swagger/index.html -->
-
 # Field Level Map APIs
 
 ## 📖 APIs core concepts
@@ -120,7 +118,7 @@ This parameter is used to make the zoned map to look like a non zoned map or mak
 
 ## 📝 API List
 
-<swagger-ui src="https://api.geosys-na.net/field-level-maps/v5/swagger/v1/swagger.json"/>
+<!-- md:swagger https://api.geosys-na.net/field-level-maps/v5/swagger/index.html -->
 
 ## ⚙️ API response 
 

--- a/docs/agro/library/FieldLevel_CropMask_API_v11092025.md
+++ b/docs/agro/library/FieldLevel_CropMask_API_v11092025.md
@@ -125,9 +125,7 @@ Return the **year(s)** in which a **specific crop** has been detected within a g
 
 Interactive API documentation is available via Swagger:
 
-[CropMask API Swagger (PROD)](https://api.geosys-na.net/cropmasks/v1/swagger/index.html)
-
-<swagger-ui src="https://api.geosys-na.net/cropmasks/v1/swagger/v1/swagger.json"/>
+<!-- md:swagger https://api.geosys-na.net/cropmasks/v1/swagger/index.html -->
  
 You can use this interface to:
 

--- a/docs/agro/library/Harvest_Detection.md
+++ b/docs/agro/library/Harvest_Detection.md
@@ -12,7 +12,6 @@ keywords:
 # icon: fontawesome/question
 #status: new
 ---
-<!-- md:swagger API|https://harvest-detection.aws.geosys.com/docs -->
 
 # Harvest Detection Computation
 
@@ -45,7 +44,7 @@ The analytic uses NDVI (1) time series data available at both LR (2) and MR (3) 
 
 ## ⚙️ API
 
-<swagger-ui src="https://harvest-detection.aws.geosys.com/openapi.json"/>
+<!-- md:swagger https://harvest-detection.aws.geosys.com/docs -->
 
 ---
 

--- a/docs/agro/library/Historical_Potential_Score.md
+++ b/docs/agro/library/Historical_Potential_Score.md
@@ -12,8 +12,6 @@ keywords:
 # icon: fontawesome/question
 #status: new
 ---
-<!-- md:swagger API|https://historical-potential-risk-score.aws.geosys.com/v1/docs -->
-
 
 # Historical Potential Score
 
@@ -45,9 +43,9 @@ The analytic uses NDVI time series data available at both MR (1) and LR (2) reso
 
 ---
 
-## ⚙️ API Access
+## ⚙️ Swagger Access
 
-<swagger-ui src="https://historical-potential-risk-score.aws.geosys.com/openapi.json"/>
+<!-- md:swagger https://historical-potential-risk-score.aws.geosys.com/v1/docs -->
 
 ---
 

--- a/docs/agro/library/In-season_Potential_Score.md
+++ b/docs/agro/library/In-season_Potential_Score.md
@@ -31,9 +31,9 @@ The figure below illustrates the expected NDVI development for a typical annual 
 
 ---
 
-## ⚙️ API Access
+## ⚙️ Swagger Access
 
-<swagger-ui src="https://inseason-potential-score.aws.geosys.com/v1/docs"/>
+<!-- md:swagger https://inseason-potential-score.aws.geosys.com/v1/docs -->
 
 ---
 

--- a/docs/agro/library/Planted_Area.md
+++ b/docs/agro/library/Planted_Area.md
@@ -12,7 +12,6 @@ keywords:
 # icon: fontawesome/question
 #status: new
 ---
-<!-- md:swagger API|https://planted-area.aws.geosys.com/docs -->
 
 # Planted Area Computation
 
@@ -37,7 +36,7 @@ The analytic uses satellite imagery captured before and after crop emergence, co
 
 ## ⚙️ API
 
-<swagger-ui src="https://planted-area.aws.geosys.com/docs"/>
+<!-- md:swagger https://planted-area.aws.geosys.com/docs -->
 
 ---
 

--- a/docs/agro/library/Regional_Monitoring.md
+++ b/docs/agro/library/Regional_Monitoring.md
@@ -76,7 +76,7 @@ Regional monitoring provides a **high-level, data-driven perspective** that supp
 
 ## ⚙️ API
 
-<swagger-ui src="https://api.geosys-na.net/Agriquest/Geosys.AgriQuest.CropMonitoring.WebApi/v0/swagger/docs/v0"/>
+<!-- md:swagger http://api.geosys.internal/Agriquest/Geosys.Agriquest.CropMonitoring.WebApi/v0/swagger/ -->
 
 ### Environment API root
 

--- a/docs/agro/library/Vegetation_time_series.md
+++ b/docs/agro/library/Vegetation_time_series.md
@@ -35,10 +35,9 @@ The service  offers three data access options:
 - **Modis data**
 
 
-## ⚙️ API Access
+## ⚙️ Swagger Access
 
-
-<swagger-ui src="https://api.geosys-na.net/vegetation-time-series/v1/swagger/v1.0/swagger.json"/>
+<!-- md:swagger http://api.geosys-na.net/vegetation-time-series/v1/swagger/index.html -->
 
 ---
 
@@ -178,9 +177,9 @@ The Medium Resolution Time Series service provides high-resolution vegetation mo
 - **Temporal Resolution**: 3-5 days (weather dependent)
 - **Historical Archive**: 2015+ (varies by sensor and region)
 
-### ⚙️ API Access
+### ⚙️ Swagger Access
 
-<swagger-ui src="https://api.geosys-na.net/field-level-maps/v5/swagger/v1/swagger.json"/>
+<!-- md:swagger https://api.geosys-na.net/field-level-maps/v5/swagger/index.html -->
 
 ### ⚙️ Parameters & Variables
 

--- a/docs/agro/library/ZARC.md
+++ b/docs/agro/library/ZARC.md
@@ -31,9 +31,9 @@ The **Agricultural Zoning of Climate Risk (ZARC)** is a policy tool that guides 
 
 ---
 
-## ⚙️ API Access
+## ⚙️ Swagger Access
 
-<swagger-ui src="https://zvjihjkwfwohudwcnbhjbpsudq0jhszp.lambda-url.us-east-1.on.aws/docs"/>
+<!-- md:swagger https://zvjihjkwfwohudwcnbhjbpsudq0jhszp.lambda-url.us-east-1.on.aws/docs -->
 
 ---
 

--- a/docs/agro/library/baresoil.md
+++ b/docs/agro/library/baresoil.md
@@ -12,7 +12,6 @@ keywords:
 # icon: fontawesome/question
 #status: new
 ---
-<!-- md:swagger API|https://bare-soil.aws.geosys.com/docs -->
 
 # Bare Soil Detection
 
@@ -36,7 +35,8 @@ The analytic uses Medium Resolution imagery throughout the specified season to c
 
 ## ⚙️ API
 
-<swagger-ui src="https://avuqeoz2lrpi2s5qovww5k4vca0itlyy.lambda-url.us-east-1.on.aws/v1/openapi-identity.json"/>
+<!-- TODO md:swagger https://bare-soil.aws.geosys.com/docs -->
+<!-- md:swagger https://avuqeoz2lrpi2s5qovww5k4vca0itlyy.lambda-url.us-east-1.on.aws/v1/docs -->
 
 ---
 

--- a/docs/agro/library/disease_risk.md
+++ b/docs/agro/library/disease_risk.md
@@ -13,7 +13,6 @@ keywords:
 # icon: fontawesome/question
 #status: new
 ---
-<!-- md:swagger API|https://t7izeqf7q5t4xseagqap5ev7xm0xpmmh.lambda-url.us-east-1.on.aws/v1/docs -->
 
 # Disease Risk Assessment
 
@@ -35,7 +34,7 @@ The analytic uses comprehensive weather data including temperature, humidity, de
 
 ## ⚙️ API
 
-<swagger-ui src="https://t7izeqf7q5t4xseagqap5ev7xm0xpmmh.lambda-url.us-east-1.on.aws/v1/openapi-identity.json"/>
+<!-- md:swagger https://t7izeqf7q5t4xseagqap5ev7xm0xpmmh.lambda-url.us-east-1.on.aws/v1/docs -->
 
 ---
 

--- a/docs/agro/library/greenness.md
+++ b/docs/agro/library/greenness.md
@@ -12,7 +12,6 @@ keywords:
 # icon: fontawesome/question
 #status: new
 ---
-<!-- md:swagger API|https://zn6hzsqoyoe3qgaoau4ssgpq440vtmpa.lambda-url.us-east-1.on.aws/docs -->
 
 # Greenness Detection
 
@@ -37,7 +36,7 @@ The analytic uses NDVI (1) time series data from satellite imagery captured thro
 
 ## ⚙️ API
 
-<swagger-ui src="https://zn6hzsqoyoe3qgaoau4ssgpq440vtmpa.lambda-url.us-east-1.on.aws/docs"/>
+<!-- md:swagger https://zn6hzsqoyoe3qgaoau4ssgpq440vtmpa.lambda-url.us-east-1.on.aws/docs -->
 
 ---
 

--- a/docs/agro/library/inseason_monitoring.md
+++ b/docs/agro/library/inseason_monitoring.md
@@ -12,7 +12,6 @@ keywords:
 # icon: fontawesome/question
 #status: new
 ---
-<!-- md:swagger API|https://5gciu5p2msxwjrt54fks3kvvxu0oxdyr.lambda-url.us-east-1.on.aws/docs -->
 
 # In-Season Monitoring
 
@@ -37,7 +36,7 @@ The analytic uses NDVI (1) time series data from satellite imagery captured afte
 
 ## ⚙️ API
 
-<swagger-ui src="https://5gciu5p2msxwjrt54fks3kvvxu0oxdyr.lambda-url.us-east-1.on.aws/openapi.json"/>
+<!-- md:swagger https://5gciu5p2msxwjrt54fks3kvvxu0oxdyr.lambda-url.us-east-1.on.aws/docs -->
 
 ---
 

--- a/docs/agro/parametric/Swagger.md
+++ b/docs/agro/parametric/Swagger.md
@@ -9,7 +9,11 @@ keywords:
 
 
 
-<swagger-ui src="https://parametric-insurance.aws.geosys.com/openapi.json"/>
+# Parametric Insurance API
+
+The interactive API reference for the Parametric Insurance service is available here:
+
+<!-- md:swagger https://parametric-insurance.aws.geosys.com/docs -->
 
 
 

--- a/docs/agro/portfolio/Historical_Assessment_API.md
+++ b/docs/agro/portfolio/Historical_Assessment_API.md
@@ -59,7 +59,7 @@ All endpoints require secure access via **Identity Server API**, which manages:
 - Token-based access (OAuth 2.0)  
 - Permission scopes to control access to specific data layers or regions
 
-<swagger-ui src="https://api.geosys-na.net/fintech/v1/swagger/v1.0/swagger.json"/>
+<!-- md:swagger https://api.geosys-na.net/fintech/v1/swagger/index.html -->
 
 ### 1. Submit a New Proposal
 **POST** `/historical-assessment/plots`

--- a/docs/doc-templates/analytic_description_template.md
+++ b/docs/doc-templates/analytic_description_template.md
@@ -17,7 +17,7 @@ Please add illustration
 
 ## API 
 
-<swagger-ui src="add_swagger_json_url"/>
+<!-- md:swagger add_swagger_docs_url -->
 
 ## Performance and accuracy
 

--- a/docs/doc-templates/collection_documentation_template.md
+++ b/docs/doc-templates/collection_documentation_template.md
@@ -158,11 +158,11 @@ Briefly describe the atmospheric correction, calibration, or classification algo
 
 ---
 
-## API Access
+## Swagger Access
 
-<!-- Remove or replace the swagger block with the correct EDS endpoint URL -->
+<!-- Replace the URL below with the link to the collection's API documentation -->
 
-<swagger-ui src="https://api.eds.earthdaily.com/openapi/<collection-id>.json"/>
+<!-- md:swagger https://api.eds.earthdaily.com/ -->
 
 ### Quick start — Python
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -4,9 +4,9 @@ title: Showcase
 
 ## Swagger integration
 
-Please make sure to use the json file and not the Open API UI.
+Link to a service's hosted API documentation with the `md:swagger` shortcode instead of embedding the Swagger UI:
 
-<swagger-ui src="https://emergence-detection.aws.geosys.com/openapi.json"/>
+<!-- md:swagger https://emergence-detection.aws.geosys.com/docs -->
 
 ## Diagram
 
@@ -246,7 +246,7 @@ For now please make sure that video is uploaded on Earthdaily Youtube account. F
 ```
 &lt;!-- md:flag swagger API Name | https://api.example.com/docs --&gt;
 ```
-This should be displayed as <!-- md:swagger API|https://harvest-detection.aws.geosys.com/docs -->
+This should be displayed as <!-- md:swagger https://harvest-detection.aws.geosys.com/docs -->
 
 
 ### Demo repo 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -571,11 +571,6 @@ markdown_extensions:
   #- pymdownx.tilde:
 
 plugins:
-  - swagger-ui-tag:
-      background: White
-      docExpansion: none
-      filter: ""
-      syntaxHighlightTheme: monokai
   - meta
   - tags
   - search:

--- a/overrides/hooks/shortcodes.py
+++ b/overrides/hooks/shortcodes.py
@@ -31,6 +31,8 @@ def on_page_markdown(
         elif type == "plugin":       return _badge_for_plugin(args, page, files)
         elif type == "extension":    return _badge_for_extension(args, page, files)
         elif type == "swagger":      return _badge_for_swagger(args, page, files)
+        elif type == "swagger-button": return _badge_for_swagger_button(args, page, files)
+        elif type == "details-button": return _badge_for_details_button(args, page, files)
         elif type == "notebook":     return _badge_for_notebook(args, page, files)
         elif type == "folder":       return _badge_for_folder(args, page, files)
         elif type == "demo":         return _badge_for_demo(args, page, files)
@@ -43,8 +45,9 @@ def on_page_markdown(
         raise RuntimeError(f"Unknown shortcode: {type}")
 
     # Find and replace all external asset URLs in current page
+    # Note: [\w-]+ allows hyphens in shortcode names (e.g. swagger-button)
     return re.sub(
-        r"<!-- md:(\w+)(.*?) -->",
+        r"<!-- md:([\w-]+)(.*?) -->",
         replace, markdown, flags = re.I | re.M
     )
 
@@ -169,15 +172,17 @@ def _badge_for_extension(text: str, page: Page, files: Files):
 
 # Create badge for swagger
 def _badge_for_swagger(text: str, page: Page, files: Files):
-    # Parse name and URL from the text argument
+    # Parse name and URL from the text argument.
+    # Two forms supported:
+    #   <!-- md:swagger https://example.com/docs -->          → label defaults to "Swagger"
+    #   <!-- md:swagger Custom label|https://example.com -->  → explicit label before the pipe
     parts = text.split("|", 1)
     if len(parts) == 2:
         name = parts[0].strip()
         url = parts[1].strip()
     else:
-        # Fallback to old behavior if no pipe separator
-        name = text
-        url = _resolve_path("conventions.md#swagger", page, files)
+        name = "Swagger"
+        url = text.strip()
     
     icon = "simple-swagger"
     icon_href = _resolve_path("conventions.md#swagger", page, files)
@@ -186,6 +191,34 @@ def _badge_for_swagger(text: str, page: Page, files: Files):
         text = f"[{name}]({url})",
         type="right"
     )
+
+# Create button-styled link for swagger (used in card grids / catalog pages)
+def _badge_for_swagger_button(text: str, page: Page, files: Files):
+    # Same arg parsing as _badge_for_swagger:
+    #   <!-- md:swagger-button https://example.com/docs -->          → label defaults to "Swagger"
+    #   <!-- md:swagger-button Custom label|https://example.com -->  → explicit label before the pipe
+    parts = text.split("|", 1)
+    if len(parts) == 2:
+        name = parts[0].strip()
+        url = parts[1].strip()
+    else:
+        name = "Swagger"
+        url = text.strip()
+    return f"[:simple-swagger: {name}]({url}){{ .md-button }}"
+
+# Create button-styled "Details" link (used next to swagger-button in card grids)
+def _badge_for_details_button(text: str, page: Page, files: Files):
+    # Same arg parsing as the other button shortcodes:
+    #   <!-- md:details-button ./detail-page.md -->          → label defaults to "Details"
+    #   <!-- md:details-button Custom label|./detail-page.md --> → explicit label before the pipe
+    parts = text.split("|", 1)
+    if len(parts) == 2:
+        name = parts[0].strip()
+        url = parts[1].strip()
+    else:
+        name = "Details"
+        url = text.strip()
+    return f"[:octicons-link-external-16: {name}]({url}){{ .md-button }}"
 
 # Create badge for notebook
 def _badge_for_notebook(text: str, page: Page, files: Files):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 mkdocs-material==9.7.6
 mkdocs<2.0
-mkdocs-swagger-ui-tag
 mkdocs-simple-blog
 pymdown-extensions
 mkdocstrings-python


### PR DESCRIPTION
Drop the mkdocs-swagger-ui-tag plugin and remove every <swagger-ui> iframe in favor of three factored shortcodes:

  * <!-- md:swagger URL -->          inline badge (detail pages)
  * <!-- md:swagger-button URL -->   Material button (catalog cards)
  * <!-- md:details-button URL -->   companion 'Details' button

All three default the label to 'Swagger' / 'Details' and accept a 'Custom label|URL' form when a non-default label is needed.

Also:
  * Rename 'API Access' headings to 'Swagger Access' where they sit above a Swagger link
  * Consolidate duplicate top-of-page badges (one badge per page, in the API section)
  * Convert Api_reference.md card buttons to the new shortcodes
  * Ignore the local .venv/ and .preview_site/ used for previewing